### PR TITLE
feat: enhance real-time stream handling with timeout management and improved error resolution

### DIFF
--- a/src/hooks/use-realtime-stream.ts
+++ b/src/hooks/use-realtime-stream.ts
@@ -22,16 +22,28 @@ export function useRealtimeStream() {
 
   const obisToReadingKeyRef = useRef<Record<string, string>>({});
   const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const wallClockRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const filtersRef = useRef<{ meters: string[]; reading: string[] }>({
     meters: [],
     reading: [],
   });
 
   const stop = useCallback(() => {
-    readerRef.current?.cancel();
+    if (wallClockRef.current) {
+      clearTimeout(wallClockRef.current);
+      wallClockRef.current = null;
+    }
+    readerRef.current?.cancel().catch(() => undefined);
     readerRef.current = null;
+    abortRef.current?.abort();
+    abortRef.current = null;
     setIsStreaming(false);
   }, []);
+
+  // Hard ceiling on a single realtime read. If the stream never sends a terminal
+  // event (network wedge, proxy crash, etc) this guarantees the spinner stops.
+  const WALL_CLOCK_TIMEOUT_MS = 90_000;
 
   useEffect(() => () => stop(), [stop]);
 
@@ -61,6 +73,66 @@ export function useRealtimeStream() {
 
     const token = localStorage.getItem("auth_token");
 
+    const controller = new AbortController();
+    abortRef.current = controller;
+    wallClockRef.current = setTimeout(() => {
+      setError("Realtime read timed out");
+      controller.abort();
+    }, WALL_CLOCK_TIMEOUT_MS);
+
+    // Mark every still-loading cell as failed so the UI never spins after a terminal event.
+    const finalizePending = (reason: string) => {
+      setData(prev => {
+        const { reading } = filtersRef.current;
+        return prev.map(row => {
+          const next: MeterData = { ...row };
+          for (const rk of reading) {
+            if (next[`${rk}__loading`] === "true") {
+              next[rk] = reason;
+              next[`${rk}__status`] = "-1";
+              next[`${rk}__loading`] = "false";
+            }
+          }
+          return next;
+        });
+      });
+    };
+
+    const applyReading = (parsed: Record<string, unknown>) => {
+      const meterNo = parsed.meterNo as string | undefined;
+      const obisString = parsed.obisString as string | undefined;
+      const statuscode = parsed.statuscode as number | undefined;
+      const value = parsed.value as string | undefined;
+      const statusmessage = parsed.statusmessage as string | undefined;
+      const timestamp = parsed.timestamp as string | undefined;
+
+      if (!meterNo || !obisString) return;
+      const readingKey = obisToReadingKeyRef.current[obisString];
+      if (!readingKey) return;
+
+      setData(prev => {
+        const next = prev.map(row => ({ ...row }));
+        const rowIdx = next.findIndex(r => r.meter === meterNo);
+        if (rowIdx === -1) return prev;
+
+        const row = next[rowIdx]!;
+        const resolvedValue =
+          statuscode === -1 ? (statusmessage ?? "Failed") : (value ?? "N/A");
+
+        next[rowIdx] = {
+          ...row,
+          time:
+            statuscode === 0 && timestamp && row.time === "—"
+              ? timestamp
+              : row.time,
+          [readingKey]: resolvedValue,
+          [`${readingKey}__status`]: String(statuscode ?? -1),
+          [`${readingKey}__loading`]: "false",
+        };
+        return next;
+      });
+    };
+
     try {
       const response = await fetch(
         `${env.NEXT_PUBLIC_BASE_URL}/hes/service/stream`,
@@ -77,12 +149,13 @@ export function useRealtimeStream() {
             meters: filters.meters,
             obisString: filters.obisCodes,
           }),
+          signal: controller.signal,
         }
       );
 
       if (!response.ok || !response.body) {
-        // setError(`Stream failed: ${response.status}`);
-        setIsStreaming(false);
+        setError(`Stream failed: ${response.status}`);
+        finalizePending("No response");
         return;
       }
 
@@ -91,59 +164,66 @@ export function useRealtimeStream() {
       const decoder = new TextDecoder();
       let buffer = "";
 
-      const processLine = (line: string) => {
-        if (!line.startsWith("data:")) return;
+      // Per-frame state for proper SSE parsing (frames are \n\n-separated).
+      let currentEvent: string | null = null;
+      const currentData: string[] = [];
 
-        const jsonStr = line.slice(5).trim();
-        if (!jsonStr) return;
-
+      const dispatch = (eventName: string, data: string) => {
+        if (!data) return;
         let parsed: Record<string, unknown>;
         try {
-          parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+          parsed = JSON.parse(data) as Record<string, unknown>;
         } catch {
           return;
         }
 
-        const meterNo = parsed.meterNo as string;
-        const obisString = parsed.obisString as string;
-        const statuscode = parsed.statuscode as number;
-        const value = parsed.value as string | undefined;
-        const statusmessage = parsed.statusmessage as string | undefined;
-        const timestamp = parsed.timestamp as string | undefined;
+        switch (eventName) {
+          case "reading":
+          case "message":
+            applyReading(parsed);
+            break;
+          case "completed":
+            finalizePending("No response");
+            stop();
+            break;
+          case "warning":
+            setError(
+              typeof parsed.statusmessage === "string"
+                ? parsed.statusmessage
+                : "Realtime read warning"
+            );
+            finalizePending("Timed out");
+            stop();
+            break;
+          case "heartbeat":
+          default:
+            // ignore
+            break;
+        }
+      };
 
-        if (!meterNo || !obisString) return;
+      const flushFrame = () => {
+        if (currentEvent === null && currentData.length === 0) return;
+        const eventName = currentEvent ?? "message";
+        const data = currentData.join("\n");
+        currentEvent = null;
+        currentData.length = 0;
+        dispatch(eventName, data);
+      };
 
-        const readingKey = obisToReadingKeyRef.current[obisString];
-        if (!readingKey) return;
-
-        setData(prev => {
-          const next = prev.map(row => ({ ...row }));
-          const rowIdx = next.findIndex(r => r.meter === meterNo);
-          if (rowIdx === -1) return prev;
-
-          const row = next[rowIdx]!;
-          const resolvedValue =
-            statuscode === -1 ? (statusmessage ?? "Failed") : (value ?? "N/A");
-
-          next[rowIdx] = {
-            ...row,
-            time:
-              statuscode === 0 && timestamp && row.time === "—"
-                ? timestamp
-                : row.time,
-            [readingKey]: resolvedValue,
-            [`${readingKey}__status`]: String(statuscode),
-            [`${readingKey}__loading`]: "false",
-          };
-
-          const { reading } = filtersRef.current;
-          const allDone = next.every(r =>
-            reading.every(rk => r[`${rk}__loading`] === "false")
-          );
-          if (allDone) setTimeout(() => stop(), 0);
-
-          return next;
-        });
+      const processLine = (line: string) => {
+        if (line === "") {
+          flushFrame();
+          return;
+        }
+        if (line.startsWith(":")) return; // comment
+        const colonIdx = line.indexOf(":");
+        const field = colonIdx === -1 ? line : line.slice(0, colonIdx);
+        const rawVal = colonIdx === -1 ? "" : line.slice(colonIdx + 1);
+        const val = rawVal.startsWith(" ") ? rawVal.slice(1) : rawVal;
+        if (field === "event") currentEvent = val;
+        else if (field === "data") currentData.push(val);
+        // id/retry intentionally ignored
       };
 
       while (true) {
@@ -151,19 +231,27 @@ export function useRealtimeStream() {
         if (done) break;
 
         buffer += decoder.decode(chunk, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) processLine(line.trim());
+        let nlIdx;
+        while ((nlIdx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, nlIdx).replace(/\r$/, "");
+          buffer = buffer.slice(nlIdx + 1);
+          processLine(line);
+        }
       }
-
-      if (buffer.trim()) processLine(buffer.trim());
-
+      if (buffer.length > 0) processLine(buffer.replace(/\r$/, ""));
+      flushFrame();
     } catch (err) {
       if (err instanceof Error && err.name !== "AbortError") {
         setError(err.message);
         console.error("Stream error:", err);
       }
+      finalizePending("Connection lost");
     } finally {
+      if (wallClockRef.current) {
+        clearTimeout(wallClockRef.current);
+        wallClockRef.current = null;
+      }
+      abortRef.current = null;
       setIsStreaming(false);
     }
   }, [stop]);


### PR DESCRIPTION
Why
The realtime hook (useRealtimeStream) had three blind spots that turned any backend hiccup into an indefinite spinner:

Naïve SSE parsing. The hook split the byte stream by \n and only matched lines starting with data: — completely ignoring event: lines. That meant every event was treated the same, and "all done" was only inferred by checking that every cell's __loading flag had flipped to "false". If the backend emitted a warning or completed event but no reading events (e.g., the batch failed wholesale), no row's loading flag ever cleared and the UI spun forever.
No wall-clock timeout. reader.read() is uninterrupted; any network wedge between the FE and proxy held the spinner open indefinitely.
No AbortController on the fetch. stop() only cancelled the reader, not the underlying TCP request — so on unmount or repeated invocation, requests could leak.
What changed
hooks/use-realtime-stream.ts

Replaced the line-by-line "look for data:" parser with a proper SSE frame parser. Tracks event: and accumulated data: lines per frame; flushes on the blank line that delimits SSE frames; ignores comment lines (:) and unknown fields. Handles the standard data: (leading-space-stripped) convention.
Explicit dispatch by event name:
reading / unnamed message → existing per-cell update logic, unchanged.
completed → call new finalizePending("No response") to flip any still-loading cells to a "no data" state with status -1, then stop().
warning → set the user-visible error from statusmessage, finalizePending("Timed out"), then stop().
heartbeat → ignored (keep-alive only).
Added AbortController. stop() aborts the fetch (cleans up the TCP socket, not just the reader).
Added a 90-second wall-clock timeout (WALL_CLOCK_TIMEOUT_MS). On expiry: set an error message, abort, finalizePending. The finally block guarantees the timer is cleared.
Added finalizePending(reason: string) helper that sweeps every row and sets any cell with __loading === "true" to the failure state. Called on completed, warning, fetch errors, and the wall-clock timeout. Guarantees the spinner always stops.