### PR TITLE
Feat realtime

### DIFF
--- a/src/hooks/use-realtime-stream.ts
+++ b/src/hooks/use-realtime-stream.ts
@@ -43,7 +43,7 @@ export function useRealtimeStream() {
 
   // Hard ceiling on a single realtime read. If the stream never sends a terminal
   // event (network wedge, proxy crash, etc) this guarantees the spinner stops.
-  const WALL_CLOCK_TIMEOUT_MS = 90_000;
+  const WALL_CLOCK_TIMEOUT_MS = 150_000;
 
   // Must match hes-backend `hes.realtime-read.max-meters` / `max-obis`.
   const MAX_METERS_PER_REQUEST = 20;


### PR DESCRIPTION
Increased the frontend wall-clock timeout:

90_000 -> 150_000
Why: a valid 20-OBIS HES call took ~96 seconds in testing, so the frontend could abort before HES completed. With progressive chunking, the UI should get results earlier, but the longer timeout still protects larger reads.