### PR TITLE
fix: update table to display online time and rename last sync label

### DIFF
--- a/src/components/hes/communication-table.tsx
+++ b/src/components/hes/communication-table.tsx
@@ -154,7 +154,7 @@ export function CommunicationTable({ searchQuery = "", activeTab = 'MD', communi
                                     {row.connectionType}
                                 </span>
                             </TableCell>
-                            <TableCell>{row.updatedAt ? new Date(row.updatedAt).toLocaleString() : '-'}</TableCell>
+                            <TableCell>{row.onlineTime ? new Date(row.onlineTime).toLocaleString() : '-'}</TableCell>
                             <TableCell onClick={(e) => e.stopPropagation()}>
                                 <DropdownMenu>
                                     <DropdownMenuTrigger asChild>
@@ -219,7 +219,7 @@ export function CommunicationTable({ searchQuery = "", activeTab = 'MD', communi
                                 <span>{selectedRow.offlineTime ? new Date(selectedRow.offlineTime).toLocaleString() : '-'}</span>
                             </div>
                             <div className="grid grid-cols-2 gap-2">
-                                <Label className="font-semibold">Last Sync:</Label>
+                                <Label className="font-semibold">Last Status Update:</Label>
                                 <span>{selectedRow.updatedAt ? new Date(selectedRow.updatedAt).toLocaleString() : '-'}</span>
                             </div>
                             {selectedRow.meter && (


### PR DESCRIPTION
Description:

The communication report's "Last Sync" column showed updatedAt — the time of the last database row write, including offline writes — not when the meter was last actually online. This produced contradictory rows showing an "Offline" status next to a "Last Sync" time within the last couple of minutes.

Changes:

The "Last Sync" column now uses onlineTime (last time the meter was actually online).
The detail dialog's old "Last Sync" field (still backed by updatedAt) is relabeled "Last Status Update" to reflect what it actually represents.