### PR TITLE
feat: implement live meter status handling and update connection logic

### DIFF
--- a/src/app/(protected)/hes/hes-communication-report/page.tsx
+++ b/src/app/(protected)/hes/hes-communication-report/page.tsx
@@ -12,13 +12,42 @@ import { ContentHeader } from "@/components/ui/content-header";
 import { ExportButton } from "@/components/ui/export-button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { NotepadText } from "lucide-react";
-import { useState, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useAllCommunicationReports } from "@/hooks/use-reports";
+import { useMeterStatusStream } from "@/hooks/use-meter-status-stream";
+import type { MeterStatusData } from "@/hooks/use-sse";
+import type { CommunicationReportData } from "@/types/reports";
+
+const applyLiveStatus = (
+  report: CommunicationReportData,
+  status?: MeterStatusData,
+) => {
+  if (!status || status.status === "CONNECTED") return report;
+
+  if (status.status === "ONLINE") {
+    return {
+      ...report,
+      connectionType: status.status,
+      onlineTime: status.lastSeen,
+      updatedAt: status.lastSeen,
+    };
+  }
+
+  return {
+    ...report,
+    connectionType: status.status,
+    offlineTime: status.lastSeen,
+    updatedAt: status.lastSeen,
+  };
+};
 
 export default function CommunicationReportPage() {
   const [openDialog, setOpenDialog] = useState(false);
   const [activeTab, setActiveTab] = useState<"MD" | "Non-MD">("MD");
   const [searchQuery, setSearchQuery] = useState("");
+  const [liveStatuses, setLiveStatuses] = useState<
+    Record<string, MeterStatusData>
+  >({});
 
   const handleOpenDialog = () => {
     setOpenDialog(true);
@@ -31,9 +60,23 @@ export default function CommunicationReportPage() {
     size: 1000,
   });
 
+  const handleLiveStatus = useCallback((status: MeterStatusData) => {
+    setLiveStatuses((previous) => ({
+      ...previous,
+      [status.meterNo]: status,
+    }));
+  }, []);
+
+  useMeterStatusStream(handleLiveStatus);
+
   const communicationData = useMemo(() => {
-    return allCommunicationData ?? [];
-  }, [allCommunicationData]);
+    return (allCommunicationData ?? []).map((report) =>
+      applyLiveStatus(
+        report,
+        report.meterNo ? liveStatuses[report.meterNo] : undefined,
+      ),
+    );
+  }, [allCommunicationData, liveStatuses]);
 
   // Filter data based on search query
   const filteredData = useMemo(() => {

--- a/src/hooks/use-hes-realtime.ts
+++ b/src/hooks/use-hes-realtime.ts
@@ -90,13 +90,13 @@ export function useMeterConnections(selectedMeters: string[]) {
           console.log(`Meter ${parsedData.meterNo} status:`, parsedData);
           setConnectionStatus((prev) => ({
             ...prev,
-            [parsedData.meterNo]: parsedData.status === "CONNECTED",
+            [parsedData.meterNo]: parsedData.status === "ONLINE",
           }));
 
           // Update query cache
           queryClient.setQueryData(
             hesQueryKeys.connectionStatus(parsedData.meterNo),
-            parsedData.status === "CONNECTED",
+            parsedData.status === "ONLINE",
           );
         }
       },

--- a/src/hooks/use-meter-status-stream.ts
+++ b/src/hooks/use-meter-status-stream.ts
@@ -1,0 +1,74 @@
+import { fetchEventSource } from "@microsoft/fetch-event-source";
+import { useEffect, useRef } from "react";
+import { env } from "@/env";
+import type { MeterStatusData } from "@/hooks/use-sse";
+
+type MeterStatusHandler = (status: MeterStatusData) => void;
+
+const isMeterStatusData = (value: unknown): value is MeterStatusData => {
+  if (!value || typeof value !== "object") return false;
+
+  const event = value as Partial<MeterStatusData>;
+  return (
+    typeof event.meterNo === "string" &&
+    typeof event.lastSeen === "string" &&
+    (event.status === "ONLINE" ||
+      event.status === "OFFLINE" ||
+      event.status === "CONNECTED")
+  );
+};
+
+export function useMeterStatusStream(onStatus: MeterStatusHandler) {
+  const onStatusRef = useRef(onStatus);
+
+  useEffect(() => {
+    onStatusRef.current = onStatus;
+  }, [onStatus]);
+
+  useEffect(() => {
+    const url = `${env.NEXT_PUBLIC_BASE_URL}/hes/service/meter-status/stream`;
+    const token = localStorage.getItem("auth_token");
+    if (!token) return;
+
+    const controller = new AbortController();
+
+    void fetchEventSource(url, {
+      method: "GET",
+      signal: controller.signal,
+      openWhenHidden: true,
+      headers: {
+        Accept: "text/event-stream",
+        Authorization: `Bearer ${token}`,
+        custom: env.NEXT_PUBLIC_CUSTOM_HEADER,
+      },
+      onopen: async (response) => {
+        if (!response.ok) {
+          throw new Error(`Meter status stream failed (${response.status})`);
+        }
+      },
+      onmessage: (message) => {
+        if (!message.data) return;
+
+        try {
+          const status = JSON.parse(message.data) as unknown;
+          if (!isMeterStatusData(status) || status.meterNo === "SYSTEM") {
+            return;
+          }
+
+          onStatusRef.current(status);
+        } catch (error) {
+          console.error("Failed to parse meter status event:", error);
+        }
+      },
+      onerror: (error) => {
+        console.error("Meter status stream error:", error);
+      },
+    }).catch((error: unknown) => {
+      if (!controller.signal.aborted) {
+        console.error("Meter status stream closed:", error);
+      }
+    });
+
+    return () => controller.abort();
+  }, []);
+}

--- a/src/hooks/use-sse.ts
+++ b/src/hooks/use-sse.ts
@@ -13,11 +13,20 @@ export interface RealTimeData {
 
 export interface MeterStatusData {
   meterNo: string;
-  status: 'CONNECTED' | 'DISCONNECTED';
-  timestamp: string;
+  status: "ONLINE" | "OFFLINE" | "CONNECTED";
+  lastSeen: string;
 }
 
-export function useSSE(url: string, p0: { onOpen: () => void; onError: () => void; onMessage: (data: unknown) => void; reconnectAttempts: number; }, enabled = true) {
+export function useSSE(
+  url: string,
+  p0: {
+    onOpen: () => void;
+    onError: () => void;
+    onMessage: (data: unknown) => void;
+    reconnectAttempts: number;
+  },
+  enabled = true,
+) {
   const [data, setData] = useState<RealTimeData[]>([]);
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
This PR updates the Communication Report to consume live meter status events from the existing meter-status SSE stream.

What Changed
Added a dedicated frontend hook to subscribe to /hes/service/meter-status/stream.
Kept the existing Communication Report API call for the initial report snapshot and meter metadata.
Merged live meter-status SSE updates into the Communication Report rows in memory.
Updated live rows when:
a meter emits ONLINE
the backend emits timeout-driven OFFLINE
Updated report timestamps from stream payloads:
Last Online At
Last Updated At
Offline Time when relevant
Aligned frontend meter-status typing with the backend event payload:
ONLINE
OFFLINE
initial system CONNECTED
Corrected existing realtime status logic to treat meter ONLINE events as connected meter activity instead of checking only for CONNECTED.

Why
The Communication Report previously depended only on the report API/database snapshot, which could appear stale when meter status changed between API refreshes or while cached report data was still being served.

The backend already exposes a meter-status SSE stream, so the frontend can use:

API data for initial report load and full row metadata
SSE events for live status freshness
This improves the accuracy of the Communication Report and reduces the delay between meter communication changes and what users see on screen.